### PR TITLE
fix: throw PlatformException on unsupported platforms

### DIFF
--- a/lib/src/device_lookup.dart
+++ b/lib/src/device_lookup.dart
@@ -1,6 +1,7 @@
 import 'package:device_marketing_names/src/types/device.dart';
 import 'package:device_marketing_names/src/types/platform.dart';
 import 'package:device_marketing_names/src/utils/text.dart';
+import 'package:flutter/services.dart';
 
 import 'data/device_identifiers.dart';
 
@@ -10,7 +11,7 @@ enum DeviceType {
   ios,
 }
 
-Future<String?> lookupDevice(
+Future<String> lookupDevice(
     PlatformInfoBase platform, DeviceInfoBase device) async {
   if (platform.isWeb()) {
     final webInfo = await device.getWebInfo();
@@ -23,7 +24,11 @@ Future<String?> lookupDevice(
       final iosInfo = await device.getIosInfo();
       return lookupName(DeviceType.ios, iosInfo.utsname.machine);
     } else {
-      return null;
+      throw PlatformException(
+        code: 'UNSUPPORTED_PLATFORM',
+        message:
+            'Device name could not be read on device with unsupported type.',
+      );
     }
   }
 }

--- a/test/device_marketing_names_test.dart
+++ b/test/device_marketing_names_test.dart
@@ -4,6 +4,7 @@ import 'package:device_marketing_names/src/device_lookup.dart';
 import 'package:device_marketing_names/src/types/device.dart';
 import 'package:device_marketing_names/src/types/platform.dart';
 import 'package:device_marketing_names/src/utils/text.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -304,6 +305,16 @@ void main() {
       expect(resultx, 'xTablet-A680');
       expect(resulty, 'yetruepad21');
       expect(resultz, 'ZX70');
+    });
+
+    test('Throw on unsupported platform', () async {
+      when(platform.isWeb()).thenReturn(false);
+      when(platform.isAndroid()).thenReturn(false);
+      when(platform.isIOS()).thenReturn(false);
+
+      final resultFuture = lookupDevice(platform, device);
+
+      expect(resultFuture, throwsA(isA<PlatformException>()));
     });
   });
 


### PR DESCRIPTION
**Issue:**
Currently, the `lookupDevice()` method in `device_lookup.dart` returns a `Future<String?>`, but the calls to this method (such as in `getNames()` in `device_marketing_names.dart` and other tests) treats the returned value as non-null with the non-null assertion operator.
On unsupported platforms (such as macOs), this understandably leads to an Error being thrown with the following message:
```
Null check operator used on a null value.
```

While developers are expected to know that these platforms are unsupported, this message also does not help communicate the issue easily to the developer.

---

**Solution:**
1. This update throws a `PlatformException` on unsupported platforms to communicate the issue in a framework-standard expected manner. This will allow developers to catch these `UNSUPPORTED_PLATFORM` flows in their multi-platform code and handle them gracefully.
2. All the different platform flows inside `lookupDevice` returned a valid non-null String except the final `else` case for the unsupported platforms. With the `PlatformException` taking the place of that `return null` now, this method has been updated to return `String` to guarantee that the null assertion in `getNames()` passes.

---

**Additional context**
A barebones "unsupported platform" test has been added to the tests file, expecting a PlatformException in such cases.

Let me know if I missed anything please. Thanks for creating this useful package!